### PR TITLE
[IMP] Search only on modules scripts

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -5,11 +5,7 @@ import glob
 import csv
 from packaging.version import parse
 from mock_classes import (
-    MockModules,
     MockTools,
-    MockModels,
-    MockMany2many,
-    MockImage,
 )
 import json
 
@@ -143,12 +139,7 @@ def analyze_migration_scripts(migrations_path, util_instance, cr):
                 continue
 
             script_conditions = [
-                ('pre-models-update-custom-fields.py', '16.0.1.3'),
-                ('post-10-assets-management.py', 'saas~14.3.1.3'),
-                ('recycle_private_partners.py', 'saas~16.4.1.3'),
-                ('end-01-attrs-views.py', 'saas~16.5.1.3'),
-                ('pre-00-ir_act_server.py', 'saas~16.5.1.3'),
-                ('pre-30-company-rules.py', 'saas~12.4.1.3')
+                # Here scripts can be manually skipped
             ]
 
             if (script_name, base_version) in script_conditions:
@@ -175,21 +166,7 @@ def analyze_migration_scripts(migrations_path, util_instance, cr):
                         'util': util_instance,
                         'cr': cr,
                         'version': str(base_version_parsed),
-                        'IR_MODELS': [],
-                        "Many2many": MockMany2many,
-                        "has_trigram": lambda cr: False,
-                        "has_unaccent": lambda cr: False,
-                        "file_open": lambda path: file_open(path),
-                        "DEFAULT_SEQUENCE": [],
-                        "modules": MockModules,
                         "tools": MockTools,
-                        "models": MockModels(),
-                        "Model": MockModels().Model,
-                        "image": MockImage(),
-                        "__file__": script_path,
-                        "_dashboard_actions": util_instance.helpers._dashboard_actions,
-                        "RefactoringTool": lambda path: None,
-                        "create_categories": lambda cr, category: None,
                     })
                 except Exception as e:
                     print(f"    ERROR executing {script_name}: {e}")

--- a/mock_classes.py
+++ b/mock_classes.py
@@ -9,25 +9,11 @@ HAS_ENTERPRISE = config['settings']['has_enterprise']
 DESTINATION_VERSION = config['versions']['destination']
 
 # --- Mock Classes ---
-# Here most of the Odoo classes are recreated as Mock classes to avoid errors when running the scripts.
-class MockModules:
-    def get_modules():
-        return []
-
-class MockDomains:
-    def _get_domain_fields(self, cr):
-        return []
-
-class MockMany2many:
-    def update_db(self, model, columns):
-        pass
-
-class MockCnx:
-    server_version = 0
+# Here most some Odoo classes are recreated as Mock classes to avoid errors when running the scripts.
 
 class MockCr:
     def __init__(self):
-        self._cnx = MockCnx()
+        # self._cnx = MockCnx()
         self.results = []
         self.rowcount = 0
 
@@ -60,99 +46,6 @@ class MockCr:
     def executemany(self, query, params=None):
         self.results = []
 
-class MockField:
-    def __init__(self, name, store=True, translate=False, index=None, manual=False, column_type=None):
-        self.name = name
-        self.store = store
-        self.translate = translate
-        self.index = index
-        self.manual = manual
-        self.column_type = column_type
-        self.unaccent = False
-
-class MockRecord:
-    def __init__(self, model):
-        self.model = model
-        self.id = 0
-        self.ids = []
-        if self.model not in  ["res.groups", "implied_ids", "all_implied_ids"]:
-            self.group_ids = MockRecord(model="res.groups")
-        if self.model == "res.groups":
-            self.implied_ids = MockRecord(model="implied_ids")
-        if self.model == "implied_ids":
-            self.all_implied_ids = MockRecord(model="all_implied_ids")
-    
-    def __sub__(self, other):
-        return MockRecord(model="unknown")
-
-    def __add__(self, other):
-        return MockRecord(model="unknown")
-
-    def write(self, vals):
-        pass
-
-class MockModel:
-    def __init__(self, model_name, fields, auto=True, _abstract=False):
-        self.name = model_name
-        self._table = model_name.replace('.', '_')
-        self._fields = {field.name: field for field in fields}
-        self._auto = auto
-        self._abstract = _abstract
-
-    def _toggle_group_multi_currency(self):
-        pass
-
-    def with_context(self, *args, **kwargs):
-        return self
-
-    def with_company(self, company):
-        return self
-
-    def search(self, args, offset=0, limit=None, order=None, count=False):
-      return []
-
-    def browse(self, id):
-        return MockRecord(model=self.name)
-
-    def _update_user_groups_view(self):
-        pass
-
-    def clear_caches(self):
-        pass
-
-class MockModels:
-    def __init__(self):
-        self.Model = MockModel("unknown", [])
-
-class MockRegistry(dict):
-    def check_indexes(self, cr, model_names):
-        pass
-
-    def __getitem__(self, item):
-        if item not in self:
-            self[item] = MockModel(item, [])
-        return super().__getitem__(item)
-
-class MockEnv:
-    def __init__(self, cr):
-        self.cr = cr
-        self.registry = MockRegistry()
-        self.context = {} 
-        ir_model_fields_model = MockModel('ir.model.fields', [])
-
-        self.registry['ir.model.fields'] = ir_model_fields_model
-        # Add more models here if needed
-
-        self.values = lambda: self.registry.values()
-
-    def __getitem__(self, key):
-        if key not in self.registry:
-            self.registry[key] = MockModel(key, [])
-        return self.registry[key]
-
-    def __getattr__(self, name):
-      return MockModel("unknown")
-
 class MockTools:
     config = {}
 
@@ -161,32 +54,6 @@ class MockTools:
             pass
         return default_util_function
 
-class MockHelpers:
-    def __getattr__(self, name):
-        def default_util_function(*args, **kwargs):
-            pass
-        return default_util_function
-
-    def _dashboard_actions(self, cr, pattern):
-        return []
-
-class MockColumns:
-    def using(self, alias):
-        pass
-
-class MockView:
-    def __enter__(self):
-        return self
-    
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def xpath(self, path):
-        return []
-
-class MockImage:
-    IMAGE_MAX_RESOLUTION = 0
- 
 class MockSavepoint:
     def __enter__(self):
         return self
@@ -198,13 +65,7 @@ class MockUtil:
    
     def __init__(self, cr, installed_modules):
         self.installed_modules = installed_modules
-        self.tables = {}
-        self.columns = MockColumns()
-        self.helpers = MockHelpers()
-        self.domains = MockDomains()
-        self.ENVIRON = {"s125_image_mixin_recompute": {"all": [], "512": []}}
-        self.NEARLYWARN = 1
-        self._logger = logging.getLogger(__name__)
+        self.ENVIRON = {}
 
     def __getattr__(self, name):
         def default_util_function(*args, **kwargs):
@@ -213,18 +74,6 @@ class MockUtil:
 
     # Mandatory patched methods
     # These methods, if not patched, will cause the scripts to fail
-    def import_script(self, path, name=None):
-        def update_rules(cr, registry):
-            pass
-        self.update_rules = update_rules
-        return self
-
-    def edit_view(self, cr, xml_id=None, view_id=None, skip_if_not_noupdate=True):
-        return MockView()
-
-    def column_exists(self, cr, table, column):
-        return True
-
     def splitlines(self, s):
         return (stripped_line for line in s.splitlines() for stripped_line in [line.split("#", 1)[0].strip()] if stripped_line)
 
@@ -240,20 +89,8 @@ class MockUtil:
     def get_fk(self, cr, table):
         return []
 
-    def log_progress(self, *args, **kwargs):
-        return "Progress"
-
-    def get_columns(self, cr, table_name, ignore=None):
-        return self.columns
-
-    def env(self, cr):
-      return MockEnv(cr)
-
     def version_gte(self, version):
         return self.parse_version(DESTINATION_VERSION) >= self.parse_version(version)
-
-    def format_query(self, cr, query, **kwargs):
-        return ""
 
     def parse_version(self, s):
         "Taken as is, from Odoo's code"
@@ -298,7 +135,13 @@ class MockUtil:
     def merge_module(self, cr, module1, module2, update_dependers=True):
         if module1 in self.installed_modules and module2 not in self.installed_modules:
             self.installed_modules.append(module2)
+            self.installed_modules.remove(module1)
             print(f"  [MERGE_MODULE] {module2} (added - merged from {module1})")
+        elif module1 in self.installed_modules and module2 in self.installed_modules:
+            self.installed_modules.remove(module1)
+            print(f"  [MERGE_MODULE] {module2} (not added - already installed)")
+        else:
+            print(f"  [MERGE_MODULE] {module2} (not added - {module1} not installed)")
 
     def force_install_module(self, cr, module_name, if_installed=None):
         if_installed = if_installed if isinstance(if_installed, (list, tuple)) else [if_installed] if if_installed else []
@@ -359,6 +202,8 @@ class MockUtil:
         if module_name in self.installed_modules:
             self.installed_modules.remove(module_name)
             print(f"  [UNINSTALL_MODULE] {module_name} (removed)")
+        else:
+            print(f"  [UNINSTALL_MODULE] {module_name} skipped - not installed")
 
     def remove_module(self, cr, module_name):
         self.uninstall_module(cr, module_name)


### PR DESCRIPTION
Instead of reading all the migration scripts, and having to patch many Odoo classes and functions, a regex is ran before analyzing the scripts.
This allows for the removal of many patches.